### PR TITLE
Don't strip query parameters from URL

### DIFF
--- a/ckanext/geoview/controllers/service_proxy.py
+++ b/ckanext/geoview/controllers/service_proxy.py
@@ -30,7 +30,7 @@ def proxy_service(self, context, data_dict):
         req = self._py_object.request
         method = req.environ["REQUEST_METHOD"]
 
-        url = url.split('?')[0] # remove potential query and fragment
+        url = url.split('#')[0] # remove potential fragment
 
         if method == "POST":
             length = int(req.environ["CONTENT_LENGTH"])

--- a/ckanext/geoview/public/js/ol2_preview.js
+++ b/ckanext/geoview/public/js/ol2_preview.js
@@ -138,7 +138,7 @@
             'wms' : function(resource, proxyUrl, proxyServiceUrl, layerProcessor) {
                 var parsedUrl = resource.url.split('#');
                 // use the original URL for the getMap, as there's no need for a proxy for image requests
-                var getMapUrl = parsedUrl[0].split('?')[0]; // remove query if any
+                var getMapUrl = parsedUrl[0];
 
                 var url = proxyServiceUrl || getMapUrl;
 


### PR DESCRIPTION
Picked from MapServer [docs](http://mapserver.org/ogc/wms_server.html#changing-the-online-resource-url):
> The following Online Resource URL is perfectly valid for a MapServer WMS according to section 6.2.2 or the WMS 1.1.1 specification:
> 
> ```
> http://my.host.com/cgi-bin/mapserv?map=mywms.map&
> ```
> 
> However, some people will argue that the above URL contains mandatory vendor-specific parameters and that this is illegal. First we would like to point that `map=..` is not considered a vendor-specific parameter in this case since it is part of the Online Resource URL which is defined as an opaque string terminated by ”?” or “&” (See [WMS 1.1.1 section 6.2.2](http://portal.opengeospatial.org/files/?artifact_id=1081&version=1&format=pdf)).