### PR TITLE
JSON resource lead to mapviewer and geoview resource previews

### DIFF
--- a/ckanext/geoview/plugin.py
+++ b/ckanext/geoview/plugin.py
@@ -131,7 +131,7 @@ class OLGeoView(GeoViewBase):
 
         view_formats = config.get('ckanext.geoview.ol_viewer.formats', '')
         if view_formats:
-            view_formats.split(' ')
+            view_formats = view_formats.split(' ')
         else:
             view_formats = GEOVIEW_FORMATS
 
@@ -183,7 +183,7 @@ class OLGeoView(GeoViewBase):
         else:
             proxy_url = data_dict['resource']['url']
             proxy_service_url = data_dict['resource']['url']
-            
+
         gapi_key = config.get('ckanext.geoview.gapi_key')
         if not p.toolkit.check_ckan_version(min_version='2.3'):
             p.toolkit.c.resource['proxy_url'] = proxy_url


### PR DESCRIPTION

view_formats wasn't being reassigned to use the list from the config
file which caused a string to string comparison rather than comparing a
string to a list item.

This caused all JSON resources to have a mapview created automatically
when geojson was specified in the config file.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply

