### PR TITLE
Unpin requirements.

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,1 +1,1 @@
-requests==1.1.0
+requests>=1.1.0


### PR DESCRIPTION
Previously, requirements in `pip-requirements.txt` where pinned to an exact version (e.g. `requests==1.1.0`). This causes problems when other CKAN-related packages (e.g. core CKAN or another extension) has the same requirement but with a different version. Therefore, only the minimally required version should be specified (e.g. `requests>=1.1.0`).

For example, CKAN 2.6.0 [requires `requests==2.10.0`](https://github.com/ckan/ckan/blob/ckan-2.6.0/requirements.txt) but ckanext-geoview [currently requires `requests=1.1.0`](https://github.com/ckan/ckanext-geoview/blob/bd78927cceff9851d73300f11347116e1bb18e37/pip-requirements.txt). Hence, if I first install CKAN and then ckanext-geoview I will end up with version 1.10.0.