### PR TITLE
workaround for #70 where (ol) WMTS layers freeze the browser

### DIFF
--- a/ckanext/geoview/public/js/vendor/ol-helpers/ol-helpers.js
+++ b/ckanext/geoview/public/js/vendor/ol-helpers/ol-helpers.js
@@ -102,10 +102,11 @@ ol.proj.addProjection(createEPSG4326Proj('EPSG:4326:LONLAT', 'enu'));
 
 
     ol.Map.prototype.addLayerWithExtent = function (layer) {
+        layer.setVisible(false);
         this.addLayer(layer)
 
         // fit to layer extent only if layer visible
-        if (layer.getVisible() && layer.getSource()) {
+        if (layer.getSource()) {
 
             var _view = this.getView();
             var zoomToExtent = function() {
@@ -122,8 +123,10 @@ ol.proj.addProjection(createEPSG4326Proj('EPSG:4326:LONLAT', 'enu'));
                     isNumeric(projectedBbox[1]) &&
                     isNumeric(projectedBbox[2]) &&
                     isNumeric(projectedBbox[3]))
-
-                    _view.fit(projectedBbox, {constrainResolution: false})
+                {
+                    _view.fit(projectedBbox, {constrainResolution: false});
+                    layer.setVisible(true);
+                }
                 else {
                     console.warn("Adding layer : could not find extent to zoom to")
                 }


### PR DESCRIPTION
Workaround for #70

A proper fix would of course be better ! Also the issue may be solved in newer versions of OL. I tried with 4.6.5 but it wasn't.