### PR TITLE
fix: geojson preview issues

### DIFF
--- a/ckanext/geoview/public/js/geojson_preview.js
+++ b/ckanext/geoview/public/js/geojson_preview.js
@@ -32,7 +32,7 @@ ckan.module('geojsonpreview', function (jQuery, _) {
       self.map = ckan.commonLeafletMap('map', this.options.map_config, {attributionControl: false});
 
       // hack to make leaflet use a particular location to look for images
-      L.Icon.Default.imagePath = this.options.site_url + 'js/vendor/leaflet/dist/images';
+      L.Icon.Default.imagePath = this.options.site_url + 'js/vendor/leaflet/images/';
 
       jQuery.getJSON(preload_resource['url']).done(
         function(data){

--- a/ckanext/geoview/public/js/shp_preview.js
+++ b/ckanext/geoview/public/js/shp_preview.js
@@ -22,7 +22,7 @@ ckan.module('shppreview', function (jQuery, _) {
       self.map = ckan.commonLeafletMap('map', this.options.map_config, {attributionControl: false});
 
       // hack to make leaflet use a particular location to look for images
-      L.Icon.Default.imagePath = this.options.site_url + 'js/vendor/leaflet/dist/images';
+      L.Icon.Default.imagePath = this.options.site_url + 'js/vendor/leaflet/images/';
 
       jQuery.get(preload_resource['url']).done(
         function(data){


### PR DESCRIPTION
geojson preview wasn't able to load files from the leaflet images directory due to the wrong path 
before fix:
<img width="1228" alt="image" src="https://github.com/user-attachments/assets/b8772e68-9da2-446b-839b-4c5d696e5408">
after fix:
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/049cce7a-acc4-47a8-a207-cfd6403a5fa2">
