### PR TITLE
Update README.md - Use preferred tile.openstreetmap.org URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ This file is a JSON encoded array of basemap definitions reproducing the structu
     {
         "title": "OSM",
         "type" : "custom",
-        "url" : "http://tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "url" : "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
         "attribution" : " Map tiles & Data by OpenStreetMap, under CC BY SA."
     },
     {


### PR DESCRIPTION
See https://github.com/openstreetmap/operations/issues/737

`ckanext/geoview/public/js/vendor/leaflet-providers/leaflet-providers.js` is up-to-date.
`ckanext/geoview/public/js/vendor/ol-helpers/ol-helpers.js` is outdated, but `ol-helpers` repositories have not been updated in 4-5 years, so it might be better to manually update it if needed.