### PR TITLE
fix(deps): bump underscore from 1.13.7 to 1.13.8 (CVE-2026-27601)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "proj4": "^2.20.2",
         "proj4leaflet": "1.0.2",
         "spin.js": "2.3.2",
-        "underscore": "1.13.7"
+        "underscore": "^1.13.8"
       }
     },
     "node_modules/@petamoriken/float16": {
@@ -227,9 +227,9 @@
       "license": "MIT"
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
     },
     "node_modules/web-worker": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "proj4": "^2.20.2",
     "proj4leaflet": "1.0.2",
     "spin.js": "2.3.2",
-    "underscore": "1.13.7"
+    "underscore": "1.13.8"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
  Underscore 1.13.7 is affected by CVE-2026-27601. This updates the                                                    
  dependency to 1.13.8 which includes the security fix.                                                              
                                                                                                                     
  - package.json: 1.13.7 → 1.13.8                                                                                      
  - package-lock.json: updated accordingly