### PR TITLE
fix: read configuration for leaflet and normalize it for usage in js

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,21 @@ ckan.views.default_views = ... geojson_view
 You can use the `ckanext.geoview.geojson.max_file_size` configuration option to define the maximum file size (in bytes) that will be rendered in the map widget. Default is 25 Mb.
 Note that this relies on the resource `size` field being set (ie it will only work with uploaded files, not linked externally).
 
+#### Base map (MapBox) example configuration
+
+```
+ckanext.spatial.common_map.type = MapBox
+ckanext.spatial.common_map.mapbox.id = mapbox/streets-v12
+ckanext.spatial.common_map.mapbox.accesstoken = <your_mapbox_public_token>
+```
+
+For envvars:
+```
+CKANEXT__SPATIAL__COMMON_MAP__TYPE=MapBox
+CKANEXT__SPATIAL__COMMON_MAP__MAPBOX__ID=mapbox/streets-v12
+CKANEXT__SPATIAL__COMMON_MAP__MAPBOX__ACCESSTOKEN=<your_mapbox_public_token>
+```
+
 
 ### Leaflet WMTS Viewer
 

--- a/ckanext/geoview/plugin.py
+++ b/ckanext/geoview/plugin.py
@@ -221,7 +221,7 @@ class GeoJSONView(GeoViewBase):
 
     def get_helpers(self):
         return {
-            "get_common_map_config_geojson": utils.get_common_map_config,
+            "get_common_map_config_geojson": utils.get_common_map_config_for_leaflet,
             "geojson_get_max_file_size": utils.get_max_file_size,
         }
 
@@ -269,7 +269,7 @@ class WMTSView(GeoViewBase):
 
     def get_helpers(self):
         return {
-            "get_common_map_config_wmts": utils.get_common_map_config,
+            "get_common_map_config_wmts": utils.get_common_map_config_for_leaflet,
         }
 
 
@@ -317,6 +317,6 @@ class SHPView(GeoViewBase):
 
     def get_helpers(self):
         return {
-            "get_common_map_config_shp": utils.get_common_map_config,
+            "get_common_map_config_shp": utils.get_common_map_config_for_leaflet,
             "get_shapefile_viewer_config": utils.get_shapefile_viewer_config,
         }

--- a/ckanext/geoview/public/js/common_map.js
+++ b/ckanext/geoview/public/js/common_map.js
@@ -37,19 +37,19 @@
 
       var baseLayer;
 
-      map = new L.Map(container, leafletMapOptions);
+      var map = new L.Map(container, leafletMapOptions);
 
-      if (mapConfig.type == 'mapbox') {
-          // MapBox base map
-          if (!mapConfig['mapbox.map_id'] || !mapConfig['mapbox.access_token']) {
-            throw '[CKAN Map Widgets] You need to provide a map ID ([account].[handle]) and an access token when using a MapBox layer. ' +
-                  'See http://www.mapbox.com/developers/api-overview/ for details';
-          }
-
-          baseLayer = L.tileLayer.provider('MapBox', {
-                id: mapConfig['mapbox.map_id'],
-                accessToken: mapConfig['mapbox.access_token']
-          });
+      if (mapConfig.type === 'mapbox') {
+        var mapboxId = mapConfig.id || '';
+        var mapboxToken = mapConfig.accessToken || '';
+        if (!mapboxId || !mapboxToken) {
+          throw '[CKAN Map Widgets] You need to provide a map ID ([account].[handle]) and an access token when using a MapBox layer. ' +
+                'See http://www.mapbox.com/developers/api-overview/ for details';
+        }
+        baseLayer = L.tileLayer.provider('MapBox', {
+          id: mapboxId,
+          accessToken: mapboxToken
+        });
 
       } else if (mapConfig.type == 'custom') {
           // Custom XYZ layer

--- a/ckanext/geoview/tests/test_map_config_for_leaflet.py
+++ b/ckanext/geoview/tests/test_map_config_for_leaflet.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+import unittest
+from unittest.mock import patch
+
+from ckanext.geoview import utils
+
+
+class TestGetCommonMapConfigForLeaflet(unittest.TestCase):
+    @patch.object(utils.toolkit.config, "get")
+    @patch.object(utils, "get_common_map_config")
+    def test_mapbox_normalizes_type_and_keys(self, mock_gcm, mock_cfg_get):
+        def cfg_get(key, default=None):
+            return {
+                "ckanext.spatial.common_map.type": "mapbox",
+                "ckanext.spatial.common_map.mapbox.id": "mapbox/streets-v12",
+                "ckanext.spatial.common_map.mapbox.accesstoken": "pk.test",
+            }.get(key, default)
+
+        mock_cfg_get.side_effect = cfg_get
+        mock_gcm.return_value = {"type": "mapbox", "mapbox.id": "ignored"}
+        out = utils.get_common_map_config_for_leaflet()
+        self.assertEqual(out["type"], "MapBox")
+        self.assertEqual(out["id"], "mapbox/streets-v12")
+        self.assertEqual(out["accessToken"], "pk.test")
+
+    @patch.object(utils.toolkit.config, "get")
+    @patch.object(utils, "get_common_map_config")
+    def test_mapbox_passes_attribution(self, mock_gcm, mock_cfg_get):
+        def cfg_get(key, default=None):
+            return {
+                "ckanext.spatial.common_map.type": "mapbox",
+                "ckanext.spatial.common_map.mapbox.id": "i",
+                "ckanext.spatial.common_map.mapbox.accesstoken": "t",
+                "ckanext.spatial.common_map.attribution": "© OpenStreetMap",
+            }.get(key, default)
+
+        mock_cfg_get.side_effect = cfg_get
+        mock_gcm.return_value = {}
+        out = utils.get_common_map_config_for_leaflet()
+        self.assertEqual(out["attribution"], "© OpenStreetMap")
+
+    @patch.object(utils.toolkit.config, "get")
+    @patch.object(utils, "get_common_map_config")
+    def test_non_mapbox_shallow_copy(self, mock_gcm, mock_cfg_get):
+        def cfg_get(key, default=None):
+            if key == "ckanext.spatial.common_map.type":
+                return "Stamen.Toner"
+            return default
+
+        mock_cfg_get.side_effect = cfg_get
+        base = {"type": "Stamen.Toner", "foo": "bar"}
+        mock_gcm.return_value = base
+        out = utils.get_common_map_config_for_leaflet()
+        self.assertIsNot(out, base)
+        self.assertEqual(out, base)
+        out["mutate"] = True
+        self.assertNotIn("mutate", base)

--- a/ckanext/geoview/tests/test_map_config_for_leaflet.py
+++ b/ckanext/geoview/tests/test_map_config_for_leaflet.py
@@ -19,7 +19,7 @@ class TestGetCommonMapConfigForLeaflet(unittest.TestCase):
         mock_cfg_get.side_effect = cfg_get
         mock_gcm.return_value = {"type": "mapbox", "mapbox.id": "ignored"}
         out = utils.get_common_map_config_for_leaflet()
-        self.assertEqual(out["type"], "MapBox")
+        self.assertEqual(out["type"], "mapbox")
         self.assertEqual(out["id"], "mapbox/streets-v12")
         self.assertEqual(out["accessToken"], "pk.test")
 

--- a/ckanext/geoview/utils.py
+++ b/ckanext/geoview/utils.py
@@ -151,6 +151,34 @@ def get_common_map_config():
     )
 
 
+def get_common_map_config_for_leaflet():
+    """Normalize common map settings for Leaflet + leaflet-providers.
+
+    * ``ckanext.spatial.common_map.mapbox.id``
+    * ``ckanext.spatial.common_map.mapbox.accesstoken``
+    """
+    raw = dict(get_common_map_config())
+    type_val = toolkit.config.get("ckanext.spatial.common_map.type") or ""
+    if not (isinstance(type_val, str) and type_val.strip().lower() == "mapbox"):
+        return raw
+
+    map_id = toolkit.config.get("ckanext.spatial.common_map.mapbox.id")
+    token = toolkit.config.get("ckanext.spatial.common_map.mapbox.accesstoken")
+
+    out = {
+        "type": "mapbox",
+        "id": "" if map_id in (None, False) else str(map_id),
+        "accessToken": "" if token in (None, False) else str(token),
+    }
+
+    for suffix in ("attribution", "subdomains", "tms"):
+        val = toolkit.config.get("ckanext.spatial.common_map." + suffix)
+        if val is not None:
+            out[suffix] = val
+
+    return out
+
+
 def get_shapefile_viewer_config():
     """
         Returns a dict with all configuration options related to the


### PR DESCRIPTION
Currently we are running into issues when using mapbox as the configuration is not read properly.
The tiles won't display even with valid configurations. This fixes that.