### PR TITLE
fix: handle None value for resource name in SHPView.can_view

### DIFF
--- a/ckanext/geoview/plugin.py
+++ b/ckanext/geoview/plugin.py
@@ -291,7 +291,7 @@ class SHPView(GeoViewBase):
     def can_view(self, data_dict):
         resource = data_dict["resource"]
         format_lower = resource.get("format", "").lower()
-        name_lower = resource.get("name", "").lower()
+        name_lower = (resource.get("name") or "").lower()
         same_domain = on_same_domain(data_dict)
 
         if format_lower in self.SHP or any([shp in name_lower for shp in self.SHP]):


### PR DESCRIPTION
resource.get('name', '') only substitutes the default when the key is absent. When the key exists with a None value, calling .lower() raises TypeError. Using 'or \"\"' coerces both absent and None cases correctly.